### PR TITLE
Update the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ Flask-Sockets==0.1
 Jinja2==2.7.1
 MarkupSafe==0.18
 Werkzeug==0.9.4
-gevent==0.13.8
-gevent-websocket==0.3.6
-greenlet==0.4.1
+#gevent==0.13.8
+#gevent-websocket==0.3.6
+greenlet==0.4.14
 gunicorn==18.0
 itsdangerous==0.23
 numpy==1.8.0


### PR DESCRIPTION
Updating the greenlet version to 0.1.14 and removing gevent, gevent-websocket works. Otherwise its giving error when installing requirements using pip.